### PR TITLE
Fixing the typo for the `-db` argument in emmtyper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .coverage
 .vscode
 .idea
+/dist

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Usage: emmtyper [OPTIONS] [FASTA]...
 Options:
   --version                       Show the version and exit.
   -w, --workflow [blast|pcr]      Choose workflow  [default: blast]
-  -d, --blast_db TEXT             Path to EMM BLAST DB  [default:
+  -db, --blast_db TEXT            Path to EMM BLAST DB  [default:
                                   /path/to/emmtyper/db/emm.fna]
   -k, --keep                      Keep BLAST and isPcr output files.
                                   [default: False]

--- a/emmtyper/__init__.py
+++ b/emmtyper/__init__.py
@@ -2,7 +2,7 @@
 emmtyper: an in silico EMM typer for Streptococcus pyogenes
 """
 __name__ = "emmtyper"
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "Andre Tan"
 __email__ = "andre.sutanto.91@gmail.com"
 __url__ = "https://github.com/MDUPHL/emmtyper"

--- a/emmtyper/bin/run_emmtyper.py
+++ b/emmtyper/bin/run_emmtyper.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
     show_default=True,
 )
 @click.option(
-    "-d",
+    "-db",
     "--blast_db",
     default=os.environ.get("EMM_DB", DEFAULT_DB),
     help="Path to EMM BLAST DB",

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,5 @@ dependencies:
     - numpy>=1.23.0
     - python-dateutil>=2.8.1
     - scipy>=1.6.0
+    - -e . # editable install of emmtyper
 prefix: /usr/local/anaconda3/envs/emmtyper


### PR DESCRIPTION
This pull request addresses a typo in the `-db/--blast_db` argument within the `emmtyper/bin/run_emmtyper.py` file. There were two `-d` arguments, one for `--blast_db` and the other for `--cluster-distance`. The typo has been corrected to ensure the proper functionality of the `-db` argument. 
To make sure the changes are reflected in the installation, please install the package directly from GitHub using:
```
pip install git+https://github.com/MDU-PHL/emmtyper.git
``` 
